### PR TITLE
remove top padding of linearlayout

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -34,7 +34,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:paddingTop="60dp">
+    >
 
     <LinearLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
Fix for issue #4. I don't think it's a problem if you just remove the padding of the LinearLayout, since the map fragment covers the whole screen anyway. The space covered by the AppBar can just be scrolled to.
